### PR TITLE
Minor updates, adding EARLS_HOSTNAME

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ served up as HTML, CSS and JavaScript.
 1. cd earls
 1. npm install
 1. set Twitter credentials in environment: TWITTER\_CONSUMER\_KEY, TWITTER\_CONSUMER\_SECRET, TWITTER\_ACCESS\_TOKEN, TWITTER\_ACCESS\_TOKEN\_SECRET
+1. set ENV about TCP/IP port and IP address using EARLS_PORT=Your-Port amd EARLS_HOSTNAME="Your-IP"
 1. ./earls.js '#c4l15'
 
 ## Heroku
@@ -22,11 +23,15 @@ before you can push there:
 
 ```
 heroku config:set EARLS_TRACK=#c4l15
+heroku config:set EARLS_PORT=Your-Port
+heroku config:set EARLS_HOSTNAME="Your-IP"
 heroku config:set TWITTER_CONSUMER_KEY=XXX
 heroku config:set TWITTER_CONSUMER_SECRET=XXX
 heroku config:set TWITTER_ACCESS_TOKEN=XXX
 heroku config:set TWITTER_ACCESS_TOKEN_SECRET=XXX
 ```
+EARLS_PORT, *earls* default port is 3000.
+EARLS_HOSTNAME, *earls* default hostname is "" (listen and bind on all local IP interfaces like "*").
 
 ## Loading
 

--- a/earls.js
+++ b/earls.js
@@ -40,7 +40,7 @@ function main(track) {
   });
 
   listenForTweets(track, db);
-  app.listen(process.env.PORT || 3000);
+  app.listen(process.env.EARLS_PORT || 3000, process.env.EARLS_HOSTNAME || "");
 }
 
 
@@ -146,7 +146,7 @@ Stats.prototype.checkTweet = function(tweet) {
 
 Stats.prototype.addResource = function(r) {
   var tweetId = 'tweet:' + r.tweet.id_str;
-  var avatar = r.tweet.user.profile_image_url;
+  var avatar = r.tweet.user.profile_image_url_https;
   var name = r.tweet.user.screen_name;
   var tweetUrl = "https://twitter.com/" + r.tweet.user.screen_name + "/statuses/" + r.tweet.id_str;
 

--- a/views/index.hbs
+++ b/views/index.hbs
@@ -2,7 +2,7 @@
 <html>
 
   <head>
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, maxiumum-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <link rel="stylesheet" href="css/foundation.css">
     <link rel="stylesheet" href="css/style.css">
     <script src="js/vendor/jquery.js"></script>


### PR DESCRIPTION
- views/index.hbs, corrects a misspelling of maxiumum-scale with
  maximum-scale. A fix for mobiles.
- earls.js, it binds with all local IPs using app.listen but setting
  only default port. Added an EARLS_HOSTNAME with defaults = "". It binds
  anyway with all local IPs.
- earls.js, changed PORT with EARLS_PORT for compatibility: PORT  and
  HOSTNAME are commonly used on Unix, avoiding conflicts.
- earls.js, current release use HTTPS for tweets & accounts but HTTP
  for avatar (profile_image_url). Using the profile_image_url_https it
  solves most crash/errors when earls publish lots of URLs and avatars.
- README.md, updates for descriptions of EARLS_PORT and EARLS_HOSTNAME.
